### PR TITLE
feat: :sparkles: More tensor attributes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,12 @@ jobs:
         commit_message: 'style fixes by ruff'
     - name: Run tests
       run: |
-        python -m pytest --cov-report xml:./pytest.xml --cov-report term --cov=hypothesis_torch tests
+        python -m pytest \
+        --junitxml=pytest.xml \
+        --cov-report=term-missing:skip-covered \
+        --cov=hypothesis_torch \
+        tests \
+        | tee pytest-coverage.txt
     - name: Pytest coverage comment
       uses: MishaKav/pytest-coverage-comment@main
       with:

--- a/hypothesis_torch/__init__.py
+++ b/hypothesis_torch/__init__.py
@@ -26,6 +26,8 @@ from hypothesis_torch.dtype import (
     BOOL_DTYPES,
     ALL_DTYPES,
 )
+from hypothesis_torch.layout import layout_strategy
+from hypothesis_torch.memory_format import memory_format_strategy
 from hypothesis_torch.module import linear_network_strategy, same_shape_activation_strategy
 from hypothesis_torch.tensor import tensor_strategy
 

--- a/hypothesis_torch/dtype.py
+++ b/hypothesis_torch/dtype.py
@@ -3,32 +3,47 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Mapping
+
+from typing_extensions import Final
 
 import numpy as np
 import numpy.typing as npt
 import torch
 from hypothesis import strategies as st
 
-SIGNED_INT_DTYPES = [torch.int8, torch.int16, torch.int32, torch.int64]
+SIGNED_INT_DTYPES: Final[tuple[torch.dtype, ...]] = (
+    torch.int8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+)
 """All signed integer dtypes supported by PyTorch."""
-UNSIGNED_INT_DTYPES = [torch.uint8]
+UNSIGNED_INT_DTYPES: Final[tuple[torch.dtype, ...]] = (torch.uint8,)
 """All unsigned integer dtypes supported by PyTorch."""
-INT_DTYPES = SIGNED_INT_DTYPES + UNSIGNED_INT_DTYPES
+INT_DTYPES: Final[tuple[torch.dtype, ...]] = SIGNED_INT_DTYPES + UNSIGNED_INT_DTYPES
 """All integer (both signed and unsigned) dtypes supported by PyTorch."""
 
-FLOAT_DTYPES = [torch.float16, torch.float32, torch.float64]
+FLOAT_DTYPES: Final[tuple[torch.dtype, ...]] = (
+    torch.float16,
+    torch.float32,
+    torch.float64,
+)
 """All floating point dtypes supported by PyTorch."""
-BFLOAT_DTYPES = [torch.bfloat16]
+BFLOAT_DTYPES: Final[tuple[torch.dtype, ...]] = (torch.bfloat16,)
 """All brain-float dtypes supported by PyTorch."""
-COMPLEX_DTYPES = [torch.complex64, torch.complex128]
+COMPLEX_DTYPES: Final[tuple[torch.dtype, ...]] = (
+    torch.complex64,
+    torch.complex128,
+)
 """All complex dtypes supported by PyTorch."""
-BOOL_DTYPES = [torch.bool]
+BOOL_DTYPES: Final[tuple[torch.dtype, ...]] = (torch.bool,)
 """All boolean dtypes supported by PyTorch."""
 
-ALL_DTYPES = INT_DTYPES + FLOAT_DTYPES + BFLOAT_DTYPES + COMPLEX_DTYPES + BOOL_DTYPES
+ALL_DTYPES: Final[tuple[torch.dtype, ...]] = INT_DTYPES + FLOAT_DTYPES + BFLOAT_DTYPES + COMPLEX_DTYPES + BOOL_DTYPES
 """All dtypes supported by PyTorch."""
 
-numpy_dtype_map: dict[torch.dtype, npt.DTypeLike] = {
+numpy_dtype_map: Final[Mapping[torch.dtype, npt.DTypeLike]] = {
     torch.int8: np.int8,
     torch.int16: np.int16,
     torch.int32: np.int32,
@@ -48,7 +63,7 @@ numpy strategies."""
 assert set(numpy_dtype_map.keys()) == set(ALL_DTYPES)
 
 
-def dtype_strategy(*, dtypes: Sequence[torch.dtype] | None = None) -> st.SearchStrategy[torch.dtype]:
+def dtype_strategy(dtypes: Sequence[torch.dtype] | None = None) -> st.SearchStrategy[torch.dtype]:
     """Strategy for generating torch dtypes.
 
     Args:

--- a/hypothesis_torch/layout.py
+++ b/hypothesis_torch/layout.py
@@ -1,0 +1,28 @@
+"""Hypothesis strategies for generating torch layouts."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import torch
+
+from hypothesis import strategies as st
+
+SUPPORTED_LAYOUTS: list[torch.layout] = [
+    torch.strided,
+    torch.sparse_coo,
+]
+
+
+def layout_strategy(accepted_layouts: Sequence[torch.layout] | None = None) -> st.SearchStrategy[torch.layout]:
+    """Strategy for generating torch layouts.
+
+    Args:
+        accepted_layouts: A sequence of layouts to sample from. If None, all supported layouts are sampled.
+    """
+    if accepted_layouts is None:
+        accepted_layouts = SUPPORTED_LAYOUTS
+    return st.sampled_from(accepted_layouts)
+
+
+st.register_type_strategy(torch.layout, layout_strategy())

--- a/hypothesis_torch/memory_format.py
+++ b/hypothesis_torch/memory_format.py
@@ -1,0 +1,31 @@
+"""Hypothesis strategies for generating torch memory formats."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import torch
+
+from hypothesis import strategies as st
+
+SUPPORTED_MEMORY_FORMATS: list[torch.memory_format] = [
+    torch.contiguous_format,
+    torch.channels_last,
+    torch.channels_last_3d,
+]
+
+
+def memory_format_strategy(
+    accepted_formats: Sequence[torch.memory_format] | None = None,
+) -> st.SearchStrategy[torch.memory_format]:
+    """Strategy for generating torch layouts.
+
+    Args:
+        accepted_formats: A sequence of layouts to sample from. If None, all supported layouts are sampled.
+    """
+    if accepted_formats is None:
+        accepted_formats = SUPPORTED_MEMORY_FORMATS
+    return st.sampled_from(accepted_formats)
+
+
+st.register_type_strategy(torch.memory_format, memory_format_strategy())

--- a/hypothesis_torch/tensor.py
+++ b/hypothesis_torch/tensor.py
@@ -17,6 +17,7 @@ from hypothesis_torch import dtype as dtype_module
 _NOT_MPS_DEVICES: Final[Sequence[torch.device]] = (
     hypothesis_torch.AVAILABLE_CPU_DEVICES + hypothesis_torch.AVAILABLE_CUDA_DEVICES
 )
+"""All devices that are not MPS devices (since MPS devices do not yet have full torch support)."""
 
 _ALLOWED_DEVICES_FROM_DTYPE: Final[Mapping[torch.dtype, Sequence[torch.device]]] = {
     torch.bool: hypothesis_torch.AVAILABLE_PHYSICAL_DEVICES,
@@ -33,6 +34,7 @@ _ALLOWED_DEVICES_FROM_DTYPE: Final[Mapping[torch.dtype, Sequence[torch.device]]]
     torch.complex64: hypothesis_torch.AVAILABLE_PHYSICAL_DEVICES,
     torch.complex128: hypothesis_torch.AVAILABLE_PHYSICAL_DEVICES,
 }
+"""A mapping from dtype to the devices that support that dtype."""
 
 
 @st.composite

--- a/hypothesis_torch/tensor.py
+++ b/hypothesis_torch/tensor.py
@@ -18,7 +18,7 @@ _NOT_MPS_DEVICES: Final[Sequence[torch.device]] = (
     hypothesis_torch.AVAILABLE_CPU_DEVICES + hypothesis_torch.AVAILABLE_CUDA_DEVICES
 )
 
-_ALLOWED_DTYPES: Final[Mapping[torch.dtype, Sequence[torch.device]]] = {
+_ALLOWED_DEVICES_FROM_DTYPE: Final[Mapping[torch.dtype, Sequence[torch.device]]] = {
     torch.bool: hypothesis_torch.AVAILABLE_PHYSICAL_DEVICES,
     torch.uint8: hypothesis_torch.AVAILABLE_PHYSICAL_DEVICES,
     torch.int8: hypothesis_torch.AVAILABLE_PHYSICAL_DEVICES,
@@ -80,7 +80,7 @@ def tensor_strategy(
 
     # We will pre-sample the device so that we can cast it to a concrete torch device
     if device is None:
-        device = st.sampled_from(_ALLOWED_DTYPES[dtype])
+        device = st.sampled_from(_ALLOWED_DEVICES_FROM_DTYPE[dtype])
     if isinstance(device, st.SearchStrategy):
         device = draw(device)
     # MPS devices do not support tensors with dtype torch.float64 and bfloat16

--- a/hypothesis_torch/test_memory_format.py
+++ b/hypothesis_torch/test_memory_format.py
@@ -1,0 +1,31 @@
+"""Test the memory_format strategies."""
+
+import unittest
+
+import hypothesis
+import torch
+import hypothesis_torch
+
+LIMITED_MEMORY_FORMATS = [torch.contiguous_format, torch.channels_last]
+
+
+class TestMemoryFormat(unittest.TestCase):
+    """Tests for the memory_format strategies."""
+
+    @hypothesis.given(memory_format=...)
+    def test_inferred_memory_format_strategy(self, memory_format: torch.memory_format) -> None:
+        """Test that the inferred memory_format strategy generates a memory_format."""
+        self.assertIsInstance(memory_format, torch.memory_format)
+
+    @hypothesis.given(
+        memory_format=hypothesis_torch.memory_format_strategy(),
+    )
+    def test_default_memory_format_strategy(self, memory_format: torch.memory_format) -> None:
+        """Test that the default memory_format strategy generates a memory_format."""
+        self.assertIsInstance(memory_format, torch.memory_format)
+
+    @hypothesis.given(memory_format=hypothesis_torch.memory_format_strategy(LIMITED_MEMORY_FORMATS))
+    def test_limited_memory_format_strategy(self, memory_format: torch.memory_format) -> None:
+        """Test that the limited memory_format strategy generates a memory_format."""
+        self.assertIsInstance(memory_format, torch.memory_format)
+        self.assertIn(memory_format, LIMITED_MEMORY_FORMATS)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,8 @@
 import hypothesis
 import os
 
-hypothesis.settings.register_profile("ci", max_examples=1000, deadline=None)
+hypothesis.settings.register_profile("ci", max_examples=100)
+hypothesis.settings.register_profile("slow", max_examples=1000)
 hypothesis.settings.register_profile("dev", max_examples=10)
 hypothesis.settings.register_profile("debug", max_examples=10, verbosity=hypothesis.Verbosity.verbose)
 hypothesis.settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))

--- a/tests/unit/test_layout.py
+++ b/tests/unit/test_layout.py
@@ -1,0 +1,31 @@
+"""Test the layout strategies."""
+
+import unittest
+
+import hypothesis
+import torch
+import hypothesis_torch
+
+LIMITED_LAYOUTS = [torch.strided]
+
+
+class TestLayout(unittest.TestCase):
+    """Tests for the layout strategies."""
+
+    @hypothesis.given(layout=...)
+    def test_inferred_layout_strategy(self, layout: torch.layout) -> None:
+        """Test that the inferred layout strategy generates a layout."""
+        self.assertIsInstance(layout, torch.layout)
+
+    @hypothesis.given(
+        layout=hypothesis_torch.layout_strategy(),
+    )
+    def test_default_layout_strategy(self, layout: torch.layout) -> None:
+        """Test that the default layout strategy generates a layout."""
+        self.assertIsInstance(layout, torch.layout)
+
+    @hypothesis.given(layout=hypothesis_torch.layout_strategy(LIMITED_LAYOUTS))
+    def test_limited_layout_strategy(self, layout: torch.layout) -> None:
+        """Test that the limited layout strategy generates a layout."""
+        self.assertIsInstance(layout, torch.layout)
+        self.assertIn(layout, LIMITED_LAYOUTS)

--- a/tests/unit/test_tensor.py
+++ b/tests/unit/test_tensor.py
@@ -73,8 +73,6 @@ class TestTensor(unittest.TestCase):
         tensor=hypothesis_torch.tensor_strategy(
             dtype=torch.float32,
             shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
-            unique=st.booleans(),
-            device=st.just(torch.device("cpu")),
             elements=st.floats(min_value=-10, max_value=10),
         )
     )
@@ -88,8 +86,6 @@ class TestTensor(unittest.TestCase):
         tensor=hypothesis_torch.tensor_strategy(
             dtype=torch.float16,
             shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
-            unique=st.booleans(),
-            device=st.just(torch.device("cpu")),
             elements=st.floats(min_value=-10, max_value=10),
         )
     )
@@ -103,8 +99,6 @@ class TestTensor(unittest.TestCase):
         tensor=hypothesis_torch.tensor_strategy(
             dtype=torch.bfloat16,
             shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
-            unique=st.booleans(),
-            device=st.just(torch.device("cpu")),
             elements=st.floats(min_value=-10, max_value=10),
         )
     )
@@ -118,8 +112,6 @@ class TestTensor(unittest.TestCase):
         tensor=hypothesis_torch.tensor_strategy(
             dtype=torch.complex64,
             shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
-            unique=st.booleans(),
-            device=st.just(torch.device("cpu")),
             elements=st.complex_numbers(),
         )
     )
@@ -133,7 +125,6 @@ class TestTensor(unittest.TestCase):
         tensor=hypothesis_torch.tensor_strategy(
             dtype=torch.int8,
             shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
-            device=st.just(torch.device("cpu")),
             elements=st.integers(**INT8_RANGE),
         )
     )
@@ -145,7 +136,6 @@ class TestTensor(unittest.TestCase):
         tensor=hypothesis_torch.tensor_strategy(
             dtype=torch.int8,
             shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
-            device=st.just(torch.device("cpu")),
             elements=st.integers(),
         )
     )
@@ -157,7 +147,6 @@ class TestTensor(unittest.TestCase):
         tensor=hypothesis_torch.tensor_strategy(
             dtype=torch.int16,
             shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
-            device=st.just(torch.device("cpu")),
             elements=st.integers(**INT16_RANGE),
         )
     )
@@ -169,7 +158,6 @@ class TestTensor(unittest.TestCase):
         tensor=hypothesis_torch.tensor_strategy(
             dtype=torch.int16,
             shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
-            device=st.just(torch.device("cpu")),
             elements=st.integers(),
         )
     )
@@ -181,7 +169,6 @@ class TestTensor(unittest.TestCase):
         tensor=hypothesis_torch.tensor_strategy(
             dtype=torch.int32,
             shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
-            device=st.just(torch.device("cpu")),
             elements=st.integers(**INT32_RANGE),
         )
     )
@@ -193,7 +180,6 @@ class TestTensor(unittest.TestCase):
         tensor=hypothesis_torch.tensor_strategy(
             dtype=torch.int32,
             shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
-            device=st.just(torch.device("cpu")),
             elements=st.integers(),
         )
     )
@@ -205,7 +191,6 @@ class TestTensor(unittest.TestCase):
         tensor=hypothesis_torch.tensor_strategy(
             dtype=torch.int64,
             shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
-            device=st.just(torch.device("cpu")),
             elements=st.integers(**INT64_RANGE),
         )
     )
@@ -217,7 +202,6 @@ class TestTensor(unittest.TestCase):
         tensor=hypothesis_torch.tensor_strategy(
             dtype=torch.int64,
             shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
-            device=st.just(torch.device("cpu")),
             elements=st.integers(),
         )
     )
@@ -229,7 +213,6 @@ class TestTensor(unittest.TestCase):
         tensor=hypothesis_torch.tensor_strategy(
             dtype=torch.uint8,
             shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
-            device=st.just(torch.device("cpu")),
             elements=st.integers(**UINT8_RANGE),
         )
     )
@@ -241,10 +224,23 @@ class TestTensor(unittest.TestCase):
         tensor=hypothesis_torch.tensor_strategy(
             dtype=torch.uint8,
             shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
-            device=st.just(torch.device("cpu")),
             elements=st.integers(),
         )
     )
     def test_uint8_tensor_with_unranged_integer_elements(self, tensor: torch.Tensor) -> None:
         """Test that specifying integer elements without a range of an uint8 tensor is of the correct dtype."""
         self.assertEqual(tensor.dtype, torch.uint8)
+
+    @hypothesis.given(
+        tensor_and_kwargs=utils.meta_strategy_constraints(
+            strategy_func=hypothesis_torch.tensor_strategy,
+            dtype=hypothesis_torch.dtype_strategy(dtypes=hypothesis_torch.INT_DTYPES),
+            shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
+        )
+    )
+    def test_int_tensor_is_filled_appropriately_if_no_elements_specified(
+        self, tensor_and_kwargs: tuple[torch.Tensor, dict[str, Any]]
+    ) -> None:
+        """Test that if no elements are specified, the tensor is filled with integers."""
+        tensor, kwargs = tensor_and_kwargs
+        self.assertEqual(tensor.dtype, kwargs["dtype"])

--- a/tests/unit/test_tensor.py
+++ b/tests/unit/test_tensor.py
@@ -268,3 +268,21 @@ class TestTensor(unittest.TestCase):
         """Test that the requires_grad argument is correctly handled."""
         tensor, kwargs = tensor_and_kwargs
         self.assertEqual(tensor.requires_grad, kwargs["requires_grad"])
+
+    @hypothesis.given(
+        tensor_and_kwargs=utils.meta_strategy_constraints(
+            strategy_func=hypothesis_torch.tensor_strategy,
+            dtype=hypothesis_torch.dtype_strategy(dtypes=hypothesis_torch.FLOAT_DTYPES),
+            shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
+            elements=st.just(st.floats(min_value=-10, max_value=10)),
+            pin_memory=st.booleans(),
+        )
+    )
+    def test_pin_memory(self, tensor_and_kwargs: tuple[torch.Tensor, dict[str, Any]]) -> None:
+        """Test that the pin_memory argument is correctly handled."""
+        tensor, kwargs = tensor_and_kwargs
+        if tensor.device == torch.device("cuda"):
+            # NOTE: This branch only runs when CUDA is available
+            self.assertEqual(tensor.is_pinned(), kwargs["pin_memory"])
+        else:
+            self.assertFalse(tensor.is_pinned())

--- a/tests/unit/test_tensor.py
+++ b/tests/unit/test_tensor.py
@@ -251,6 +251,20 @@ class TestTensor(unittest.TestCase):
             shape=tuple(),
         )
     )
-    def empty_tuple_shape_yields_scalar_tensor(self, tensor: torch.Tensor) -> None:
+    def test_empty_tuple_shape_yields_scalar_tensor(self, tensor: torch.Tensor) -> None:
         """Test that an empty tuple shape yields a scalar tensor."""
         self.assertEqual(tensor.shape, torch.Size([]))
+
+    @hypothesis.given(
+        tensor_and_kwargs=utils.meta_strategy_constraints(
+            strategy_func=hypothesis_torch.tensor_strategy,
+            dtype=hypothesis_torch.dtype_strategy(dtypes=hypothesis_torch.FLOAT_DTYPES),
+            shape=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=3).map(tuple),
+            elements=st.just(st.floats(min_value=-10, max_value=10)),
+            requires_grad=st.booleans(),
+        )
+    )
+    def test_requires_grad(self, tensor_and_kwargs: tuple[torch.Tensor, dict[str, Any]]) -> None:
+        """Test that the requires_grad argument is correctly handled."""
+        tensor, kwargs = tensor_and_kwargs
+        self.assertEqual(tensor.requires_grad, kwargs["requires_grad"])

--- a/tests/unit/test_tensor.py
+++ b/tests/unit/test_tensor.py
@@ -244,3 +244,13 @@ class TestTensor(unittest.TestCase):
         """Test that if no elements are specified, the tensor is filled with integers."""
         tensor, kwargs = tensor_and_kwargs
         self.assertEqual(tensor.dtype, kwargs["dtype"])
+
+    @hypothesis.given(
+        tensor=hypothesis_torch.tensor_strategy(
+            dtype=hypothesis_torch.dtype_strategy(),
+            shape=tuple(),
+        )
+    )
+    def empty_tuple_shape_yields_scalar_tensor(self, tensor: torch.Tensor) -> None:
+        """Test that an empty tuple shape yields a scalar tensor."""
+        self.assertEqual(tensor.shape, torch.Size([]))


### PR DESCRIPTION
This PR introduces functionality to the tensor strategy that allows specifying values or strategies for the following tensor attributes:
- `requires_grad`
- `pin_memory`
- `memory_format`
- `layout`

Note:
- Although `layout` seems to support multiple sparse tensor layouts, only COO is documented: https://pytorch.org/docs/stable/tensor_attributes.html#torch-layout. So that is the only sparse layout included in this PR. Additional work can expand that.

This allows the tensor strategy to generate a wider variety of tensors. Almost any tensor that could be generated using `torch.tensor` or `torch.from_numpy` can now be an output of `tensor_strategy`. Additionally, the result of casting any of those tensors to any supported `memory_format` and `layout` can also be generated.