### PR TITLE
fix: :bug: do not generate inf values if elements has infinity disabled for bfloat16 tensors.

### DIFF
--- a/hypothesis_torch/dtype.py
+++ b/hypothesis_torch/dtype.py
@@ -50,7 +50,7 @@ numpy_dtype_map: Final[Mapping[torch.dtype, npt.DTypeLike]] = {
     torch.float16: np.float16,
     torch.float32: np.float32,
     torch.float64: np.float64,
-    torch.bfloat16: np.float32,  # Numpy does not have a bf16, but it has the same dynamic range as f32
+    torch.bfloat16: np.float32,  # Numpy does not have a bf16, but it is a strict subset of fp32
     torch.complex64: complex,
     torch.complex128: complex,
     torch.bool: np.bool_,
@@ -60,7 +60,7 @@ numpy strategies."""
 
 float_width_map: Final[Mapping[torch.dtype, Literal[16, 32, 64]]] = {
     torch.float16: 16,
-    torch.bfloat16: 32,  # Numpy does not have a bf16, but it has the same dynamic range as f32
+    torch.bfloat16: 32,  # Numpy does not have a bf16, but it is a strict subset of f32
     torch.float32: 32,
     torch.float64: 64,
 }


### PR DESCRIPTION
Before, if a float strategy that prevented infinities was provided to as `elements` to `tensor_strategy`, the resultant tensor could still occasionally have infinities because the strategy would generate float32 values that exceeded the maximium/minimum values for bfloat16.

Fixes #20 .

This commit: https://github.com/qthequartermasterman/hypothesis-torch/pull/21/commits/cda8577aebf2bed7d8c86a8e5ac1c1d19d5cd57c

Works fine, but is slow, because of excessive filtering for `bfloat16` tensors.

This commit, however: https://github.com/qthequartermasterman/hypothesis-torch/pull/21/commits/0227a8b98a263a9d0a6cb76efe7e3e2d2bfce4ed

Generates almost an order of magnitude fewer invalid examples, but spend significantly longer (several seconds longer for the `test_no_infinities_generated` test case) in shrinking. I'd rather use this technique, since it is cleaner, but I don't know why `hypothesis` takes so long to generate examples. Especially since when I profile it, the actual generation itself isn't taking that long.

