### PR TITLE
docs(version): :memo: remove reference to python 3.8 in classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
   # Specify the Python versions you support here.
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Currently the required-python is >=3.9.  This removers the classifier that shows python 3.8 is supported.