### PR TITLE
ci: store hypothesis database in GitHub Actions to allow reproducing failures locally

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -64,6 +64,14 @@ jobs:
       if: ${{ inputs.lint }}
       with:
         commit_message: 'style fixes by ruff'
+    - name: Download example database
+      uses: dawidd6/action-download-artifact@v2.24.3
+      with:
+        name: hypothesis-example-db
+        path: .hypothesis/examples
+        if_no_artifact_found: warn
+        workflow_conclusion: completed
+
     - name: Run tests
       run: |
         python -m pytest \
@@ -71,6 +79,14 @@ jobs:
         --cov-report=term-missing:skip-covered \
         --cov=hypothesis_torch \
         tests
+
+    - name: Upload example database
+      uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: hypothesis-example-db
+        path: .hypothesis/examples
+
     - name: Pytest coverage comment
       uses: MishaKav/pytest-coverage-comment@main
       with:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,30 @@
 """Global test configuration."""
 
+import datetime
+
 import hypothesis
 import os
+from hypothesis import database
 
-hypothesis.settings.register_profile("ci", max_examples=100)
-hypothesis.settings.register_profile("slow", max_examples=1000)
-hypothesis.settings.register_profile("dev", max_examples=10)
-hypothesis.settings.register_profile("fast", max_examples=3)
-hypothesis.settings.register_profile("debug", max_examples=10, verbosity=hypothesis.Verbosity.verbose)
+
+local = database.DirectoryBasedExampleDatabase(".hypothesis/examples")
+shared = database.ReadOnlyDatabase(
+    database.GitHubArtifactDatabase(
+        "qthequartermaserman",
+        "hypothesis-torch",
+        cache_timeout=datetime.timedelta(days=7),
+    )
+)
+
+hypothesis.settings.register_profile("ci", max_examples=100, database=local)
+hypothesis.settings.register_profile("default", max_examples=100, database=database.MultiplexedDatabase(local, shared))
+hypothesis.settings.register_profile("slow", max_examples=1000, database=database.MultiplexedDatabase(local, shared))
+hypothesis.settings.register_profile("dev", max_examples=10, database=database.MultiplexedDatabase(local, shared))
+hypothesis.settings.register_profile("fast", max_examples=3, database=database.MultiplexedDatabase(local, shared))
+hypothesis.settings.register_profile(
+    "debug",
+    max_examples=10,
+    verbosity=hypothesis.Verbosity.verbose,
+    database=database.MultiplexedDatabase(local, shared),
+)
 hypothesis.settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))


### PR DESCRIPTION
Implementing a shared Hypothesis database that is cached in GitHub Actions and automatically pulled locally to dev machines.

See this for more details.

https://hypothesis.readthedocs.io/en/latest/database.html#hypothesis.database.GitHubArtifactDatabase