### PR TITLE
ci: fix missing coverage comment by creating pytest-coverage.txt file during build

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -74,11 +74,12 @@ jobs:
 
     - name: Run tests
       run: |
+        set -o pipefail
         python -m pytest \
         --junitxml=pytest.xml \
         --cov-report=term-missing:skip-covered \
         --cov=hypothesis_torch \
-        tests
+        tests | tee pytest-coverage.txt
 
     - name: Upload example database
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
I originally removed the `tee` when creating the pytest-coverage.txt file so that when the pytest failed (i.e. a test failed), it would fail the github workflow. But this meant the coverage txt file was never created so, coverage comments weren't showing up.