### PR TITLE
fix: Only generate `mps:0` devices.

### DIFF
--- a/hypothesis_torch/device.py
+++ b/hypothesis_torch/device.py
@@ -10,7 +10,7 @@ from hypothesis import strategies as st
 
 AVAILABLE_CPU_DEVICES: Final = [torch.device("cpu")]
 AVAILABLE_CUDA_DEVICES: Final = [torch.device("cuda", i) for i in range(torch.cuda.device_count())]
-AVAILABLE_MPS_DEVICES: Final = [torch.device("mps")] if torch.backends.mps.is_available() else []
+AVAILABLE_MPS_DEVICES: Final = [torch.device("mps:0")] if torch.backends.mps.is_available() else []
 AVAILABLE_META_DEVICES: Final = [torch.device("meta")]
 
 AVAILABLE_PHYSICAL_DEVICES: Final = AVAILABLE_CPU_DEVICES + AVAILABLE_CUDA_DEVICES + AVAILABLE_MPS_DEVICES


### PR DESCRIPTION
Because `torch.device('mps') != torch.device('mps:0')`, and tensors sent to either device will end up on `mps:0`, it feels fitting to only include `mps:0` in the device strategy, similar to how we only generate indexed `cuda` devices.

```python
import torch

mps_device = torch.device("mps")
mps_0_device = torch.device("mps:0")
print(mps_device, mps_0_device, mps_device == mps_0_device)  # mps mps:0 False  # I expect these to be equal, because tensors on the mps device get placed on the mps:0 device

mps_tensor = torch.randn(2, 3, device=mps_device)
mps_0_tensor = torch.randn(2, 3, device=mps_0_device)
print(mps_tensor.device, mps_0_tensor.device, mps_tensor.device == mps_0_tensor.device)  # mps:0 mps:0 True  # This matches what I expect
```