### PR TITLE
feat: support pytorch 2.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        torch-version: ['2.1.2', '2.2.2', '2.3.1', '2.4.0', '']
+        torch-version: ['2.1.2', '2.2.2', '2.3.1', '2.4.0', '2.5.1', '']
         exclude:
           - python-version: '3.12'
             torch-version: '2.1.2'

--- a/hypothesis_torch/optim.py
+++ b/hypothesis_torch/optim.py
@@ -62,6 +62,7 @@ HYPERPARAM_OVERRIDE_STRATEGIES: Final[dict[str, st.SearchStrategy]] = {
     "nesterov": st.booleans(),
     "initial_accumulator_value": _ZERO_TO_ONE_FLOATS,
     "fused": st.booleans() if torch.cuda.is_available() else st.just(False),
+    "beta2_decay": st.floats(max_value=0.0, exclude_max=False, allow_nan=False, allow_infinity=False),
 }
 
 

--- a/hypothesis_torch/optim.py
+++ b/hypothesis_torch/optim.py
@@ -63,7 +63,7 @@ HYPERPARAM_OVERRIDE_STRATEGIES: Final[dict[str, st.SearchStrategy]] = {
     "initial_accumulator_value": _ZERO_TO_ONE_FLOATS,
     "fused": st.booleans() if torch.cuda.is_available() else st.just(False),
     "beta2_decay": st.floats(max_value=0.0, exclude_max=False, allow_nan=False, allow_infinity=False),
-    "d": _ZERO_TO_ONE_FLOATS,
+    "d": st.floats(min_value=1.0, exclude_min=False, allow_nan=False, allow_infinity=False),
 }
 
 

--- a/hypothesis_torch/optim.py
+++ b/hypothesis_torch/optim.py
@@ -63,6 +63,7 @@ HYPERPARAM_OVERRIDE_STRATEGIES: Final[dict[str, st.SearchStrategy]] = {
     "initial_accumulator_value": _ZERO_TO_ONE_FLOATS,
     "fused": st.booleans() if torch.cuda.is_available() else st.just(False),
     "beta2_decay": st.floats(max_value=0.0, exclude_max=False, allow_nan=False, allow_infinity=False),
+    "d": _ZERO_TO_ONE_FLOATS,
 }
 
 
@@ -121,6 +122,11 @@ def optimizer_strategy(
     # Adam cannot be both fused and differentiable simultaneously
     if "differentiable" in kwargs and kwargs["differentiable"] and "fused" in kwargs and kwargs["fused"]:
         kwargs.pop("differentiable")
+
+    # Adafactor has a unique eps: Tuple[Optional[float], float], with eps[0] being None or >=0 and eps[1] >=0
+    if "Adafactor" in optimizer_type.__name__:  # type: ignore
+        eps0 = draw(st.one_of(st.none(), _ZERO_TO_ONE_FLOATS))
+        kwargs["eps"] = (eps0, draw(_ZERO_TO_ONE_FLOATS))
 
     hypothesis.note(f"Chosen optimizer type: {optimizer_type}")
     hypothesis.note(f"Chosen optimizer hyperparameters: {kwargs}")


### PR DESCRIPTION
The optimizer strategy can fail to create valid examples of the new Adafactor optimizer (introduced in 2.5.1, I think), because it expects a `beta2_decay<=0`, which wasn't accounted for.